### PR TITLE
Fix incorrect return value from configs iterator

### DIFF
--- a/custom_components/uniled/lib/sptech_model.py
+++ b/custom_components/uniled/lib/sptech_model.py
@@ -1098,7 +1098,7 @@ class SPTechModel(SPTechFX):
             if light_type in self.configs:
                 return self.configs[light_type]
             if len(self.configs) > 1:
-                return next(iter(self.configs))
+                return self.configs[next(iter(self.configs))]
         return None
 
     def match_channel_effect_type(


### PR DESCRIPTION
The original code returned the iterator key directly. Updated to correctly return the corresponding value from `configs` dict.