### PR TITLE
Fix Home Assistant 2026.3 light API compatibility

### DIFF
--- a/custom_components/uniled/light.py
+++ b/custom_components/uniled/light.py
@@ -20,7 +20,6 @@ from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_MODE,
     ATTR_COLOR_TEMP_KELVIN,
-    ATTR_COLOR_TEMP,
     ATTR_EFFECT,
     ATTR_RGB_COLOR,
     ATTR_RGBW_COLOR,
@@ -32,7 +31,6 @@ from homeassistant.components.light import (
     LightEntity,
     LightEntityFeature,
     ColorMode,
-    color_supported,
 )
 
 from .entity import (
@@ -71,12 +69,14 @@ from .lib.const import (
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
-import asyncio
 import logging
 
 _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 1
+
+# Legacy HA light attribute kept for backward compatibility with UniLED internals
+ATTR_COLOR_TEMP_LEGACY = "color_temp"
 
 
 async def async_setup_entry(
@@ -144,18 +144,18 @@ class UniledLightEntity(
         super()._async_update_attrs()
 
     @property
-    def color_mode(self) -> ColorMode | str | None:
+    def color_mode(self) -> ColorMode | None:
         """Return the color mode of the light."""
         if self.channel.has(ATTR_COLOR_MODE):
             return self.channel.get(ATTR_COLOR_MODE, ColorMode.ONOFF)
         if not self._attr_color_mode:
-            supported = self.supported_color_modes()
-            if supported and len(supported) and not self._attr_color_mode:
-                return supported[0]
+            supported = self.supported_color_modes
+            if supported and not self._attr_color_mode:
+                return next(iter(supported))
         return self._attr_color_mode
 
     @property
-    def supported_color_modes(self) -> set[ColorMode] | set[str] | None:
+    def supported_color_modes(self) -> set[ColorMode] | None:
         """Supported color modes."""
         modes = self.__supported_color_modes
         if not isinstance(modes, set):
@@ -163,7 +163,7 @@ class UniledLightEntity(
         return modes
     
     @property
-    def __supported_color_modes(self) -> set[ColorMode] | set[str] | None:
+    def __supported_color_modes(self) -> set[ColorMode] | None:
         """Supported color modes."""
         if self.channel.has(ATTR_SUPPORTED_COLOR_MODES):
             return self.channel.get(ATTR_SUPPORTED_COLOR_MODES, {ColorMode.ONOFF})
@@ -177,7 +177,7 @@ class UniledLightEntity(
             self._attr_supported_color_modes = {ColorMode.RGB}
             self._attr_color_mode = ColorMode.RGB
         elif (
-            self.channel.has(ATTR_COLOR_TEMP)
+            self.channel.has(ATTR_COLOR_TEMP_LEGACY)
             or self.channel.has(ATTR_COLOR_TEMP_KELVIN)
             or self.channel.has(ATTR_UL_CCT_COLOR)
         ):
@@ -232,23 +232,6 @@ class UniledLightEntity(
         return self.device.get_state(self.channel, ATTR_RGBWW_COLOR)
 
     @property
-    def color_temp(self) -> int | None:
-        """Return the mired value of this light."""
-        if self.channel.has(ATTR_COLOR_TEMP):
-            return self.channel.get(ATTR_COLOR_TEMP)
-        return color_temperature_kelvin_to_mired(self.color_temp_kelvin)
-
-    @property
-    def max_mireds(self) -> int:
-        """Return the warmest color_temp that this light supports."""
-        return self.channel.get(ATTR_HA_MAX_MIREDS, UNILED_DEFAULT_MAX_MIREDS)
-
-    @property
-    def min_mireds(self) -> int:
-        """Return the coldest color_temp that this light supports."""
-        return self.channel.get(ATTR_HA_MIN_MIREDS, UNILED_DEFAULT_MIN_MIREDS)
-
-    @property
     def color_temp_kelvin(self) -> int | None:
         """Return the kelvin value of this light."""
         if self.channel.has(ATTR_COLOR_TEMP_KELVIN):
@@ -262,11 +245,10 @@ class UniledLightEntity(
                     self.max_color_temp_kelvin,
                 )
             return kelvin
-        elif self.channel.has(ATTR_COLOR_TEMP):
-            kelvin = color_temperature_mired_to_kelvin(
-                self.channel.get(ATTR_COLOR_TEMP)
+        elif self.channel.has(ATTR_COLOR_TEMP_LEGACY):
+            return color_temperature_mired_to_kelvin(
+                self.channel.get(ATTR_COLOR_TEMP_LEGACY)
             )
-            return kelvin
         return self._attr_color_temp_kelvin
 
     @property
@@ -370,8 +352,13 @@ class UniledLightEntity(
             # Process any color temperature changes here to do a kelvin
             # to cold, warm and brightness conversion first etc.
             #
-            mireds = kwargs.pop(ATTR_COLOR_TEMP, None)
-            if (kelvin := kwargs.pop(ATTR_COLOR_TEMP_KELVIN, None)) is not None:
+            mireds = kwargs.pop(ATTR_COLOR_TEMP_LEGACY, None)
+            kelvin = kwargs.pop(ATTR_COLOR_TEMP_KELVIN, None)
+
+            if kelvin is None and mireds is not None:
+                kelvin = color_temperature_mired_to_kelvin(mireds)
+
+            if kelvin is not None:
                 if self.channel.has(ATTR_COLOR_TEMP_KELVIN):
                     success = await self.device.async_set_state(
                         self.channel, ATTR_COLOR_TEMP_KELVIN, kelvin
@@ -387,11 +374,12 @@ class UniledLightEntity(
                     success = await self.device.async_set_state(
                         self.channel, ATTR_UL_CCT_COLOR, (cold, warm, level, kelvin)
                     )
-                elif self.channel.has(ATTR_COLOR_TEMP):
-                    if mireds is not None:
-                        await self.device.async_set_state(
-                            self.channel, ATTR_COLOR_TEMP, mireds
-                        )
+                elif self.channel.has(ATTR_COLOR_TEMP_LEGACY):
+                    success = await self.device.async_set_state(
+                        self.channel,
+                        ATTR_COLOR_TEMP_LEGACY,
+                        color_temperature_kelvin_to_mired(kelvin),
+                    )
 
             # Process any other commands
             #


### PR DESCRIPTION
Fixes #118
Related: #124

Home Assistant 2026.3 removed deprecated light API features such as
ATTR_COLOR_TEMP, min_mireds, and max_mireds.

This PR updates the UniLED light platform to use the new Kelvin-based API
and fixes compatibility issues that prevent the integration from loading.

Main changes:
- migrate to ATTR_COLOR_TEMP_KELVIN
- remove deprecated LightEntity properties (color_temp, min_mireds, max_mireds)
- ensure supported_color_modes returns valid ColorMode
- fix property access in color_mode / supported_color_modes
- add compatibility fallback for legacy "color_temp" values internally

Tested on:
Home Assistant Core 2026.3.x

Without this patch the integration fails with:

ImportError: cannot import name 'ATTR_COLOR_TEMP'

Reference:
https://developers.home-assistant.io/blog/2026/02/23/remove-deprecate-light-features/