### PR TITLE
Fix light entity creation on Home Assistant 2026.3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 
 You can install this component through [HACS](https://hacs.xyz/) to easily receive updates.
 
-After installing HACS, visit the HACS _Integrations_ pane and add `https://github.com/monty68/uniled` as an `Integration` by following [these instructions](https://hacs.xyz/docs/faq/custom_repositories/). You'll then be able to install it through the _Integrations_ pane.
+After installing HACS, visit the HACS _Integrations_ pane and add `https://github.com/satvilla/uniled` as an `Integration` by following [these instructions](https://hacs.xyz/docs/faq/custom_repositories/). You'll then be able to install it through the _Integrations_ pane.
 
 ### Manual Installation
 
@@ -94,7 +94,7 @@ If you want to contribute to UniLED, please read the [Contribution guidelines](C
 
 ***
 
-[uniled]: https://github.com/monty68/uniled
+[uniled]: https://github.com/satvilla/uniled
 [ha-logo]: docs/img/ha-logo-32x32.png
 [SP107E]: docs/sp107e.md
 [SP110E]: docs/sp110e.md
@@ -102,7 +102,7 @@ If you want to contribute to UniLED, please read the [Contribution guidelines](C
 [SP61xE]: docs/sp61Xe.md
 [SP620E]: docs/sp620e.md
 [Info]: info.md
-[user_profile]: https://github.com/monty68
+[user_profile]: https://github.com/satvilla
 [maintenance-shield]: https://img.shields.io/badge/maintainer-Monty-blue.svg?style=for-the-badge
 [buymecoffee]: https://www.buymeacoffee.com/monty68
 [buymecoffeebadge]: https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg?style=for-the-badge

--- a/custom_components/uniled/lib/ble/banlanx_6xx.py
+++ b/custom_components/uniled/lib/ble/banlanx_6xx.py
@@ -1085,6 +1085,9 @@ class BanlanX6xx(SP6xxEProxy):
                             # supported_color_modes = set(white_mode)
                             supported_color_modes.add(white_mode)
 
+                        if COLOR_MODE_RGB in supported_color_modes:
+                            supported_color_modes.discard(COLOR_MODE_BRIGHTNESS)
+
                         device.master.set(ATTR_HA_SUPPORTED_COLOR_MODES, supported_color_modes)
                         device.master.set(ATTR_HA_COLOR_MODE, 
                             COLOR_MODE_RGB 

--- a/custom_components/uniled/light.py
+++ b/custom_components/uniled/light.py
@@ -20,7 +20,6 @@ from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_MODE,
     ATTR_COLOR_TEMP_KELVIN,
-    ATTR_COLOR_TEMP,
     ATTR_EFFECT,
     ATTR_RGB_COLOR,
     ATTR_RGBW_COLOR,
@@ -32,7 +31,6 @@ from homeassistant.components.light import (
     LightEntity,
     LightEntityFeature,
     ColorMode,
-    color_supported,
 )
 
 from .entity import (
@@ -71,12 +69,14 @@ from .lib.const import (
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
-import asyncio
 import logging
 
 _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 1
+
+# Legacy HA light attribute kept for backward compatibility with UniLED internals
+ATTR_COLOR_TEMP_LEGACY = "color_temp"
 
 
 async def async_setup_entry(
@@ -144,18 +144,18 @@ class UniledLightEntity(
         super()._async_update_attrs()
 
     @property
-    def color_mode(self) -> ColorMode | str | None:
+    def color_mode(self) -> ColorMode | None:
         """Return the color mode of the light."""
         if self.channel.has(ATTR_COLOR_MODE):
             return self.channel.get(ATTR_COLOR_MODE, ColorMode.ONOFF)
         if not self._attr_color_mode:
-            supported = self.supported_color_modes()
-            if supported and len(supported) and not self._attr_color_mode:
-                return supported[0]
+            supported = self.supported_color_modes
+            if supported and not self._attr_color_mode:
+                return next(iter(supported))
         return self._attr_color_mode
 
     @property
-    def supported_color_modes(self) -> set[ColorMode] | set[str] | None:
+    def supported_color_modes(self) -> set[ColorMode] | None:
         """Supported color modes."""
         modes = self.__supported_color_modes
         if not isinstance(modes, set):
@@ -163,7 +163,7 @@ class UniledLightEntity(
         return modes
     
     @property
-    def __supported_color_modes(self) -> set[ColorMode] | set[str] | None:
+    def __supported_color_modes(self) -> set[ColorMode] | None:
         """Supported color modes."""
         if self.channel.has(ATTR_SUPPORTED_COLOR_MODES):
             return self.channel.get(ATTR_SUPPORTED_COLOR_MODES, {ColorMode.ONOFF})
@@ -177,7 +177,7 @@ class UniledLightEntity(
             self._attr_supported_color_modes = {ColorMode.RGB}
             self._attr_color_mode = ColorMode.RGB
         elif (
-            self.channel.has(ATTR_COLOR_TEMP)
+            self.channel.has(ATTR_COLOR_TEMP_LEGACY)
             or self.channel.has(ATTR_COLOR_TEMP_KELVIN)
             or self.channel.has(ATTR_UL_CCT_COLOR)
         ):
@@ -232,23 +232,6 @@ class UniledLightEntity(
         return self.device.get_state(self.channel, ATTR_RGBWW_COLOR)
 
     @property
-    def color_temp(self) -> int | None:
-        """Return the mired value of this light."""
-        if self.channel.has(ATTR_COLOR_TEMP):
-            return self.channel.get(ATTR_COLOR_TEMP)
-        return color_temperature_kelvin_to_mired(self.color_temp_kelvin)
-
-    @property
-    def max_mireds(self) -> int:
-        """Return the warmest color_temp that this light supports."""
-        return self.channel.get(ATTR_HA_MAX_MIREDS, UNILED_DEFAULT_MAX_MIREDS)
-
-    @property
-    def min_mireds(self) -> int:
-        """Return the coldest color_temp that this light supports."""
-        return self.channel.get(ATTR_HA_MIN_MIREDS, UNILED_DEFAULT_MIN_MIREDS)
-
-    @property
     def color_temp_kelvin(self) -> int | None:
         """Return the kelvin value of this light."""
         if self.channel.has(ATTR_COLOR_TEMP_KELVIN):
@@ -262,11 +245,10 @@ class UniledLightEntity(
                     self.max_color_temp_kelvin,
                 )
             return kelvin
-        elif self.channel.has(ATTR_COLOR_TEMP):
-            kelvin = color_temperature_mired_to_kelvin(
-                self.channel.get(ATTR_COLOR_TEMP)
+        elif self.channel.has(ATTR_COLOR_TEMP_LEGACY):
+            return color_temperature_mired_to_kelvin(
+                self.channel.get(ATTR_COLOR_TEMP_LEGACY)
             )
-            return kelvin
         return self._attr_color_temp_kelvin
 
     @property
@@ -370,8 +352,13 @@ class UniledLightEntity(
             # Process any color temperature changes here to do a kelvin
             # to cold, warm and brightness conversion first etc.
             #
-            mireds = kwargs.pop(ATTR_COLOR_TEMP, None)
-            if (kelvin := kwargs.pop(ATTR_COLOR_TEMP_KELVIN, None)) is not None:
+            mireds = kwargs.pop(ATTR_COLOR_TEMP_LEGACY, None)
+            kelvin = kwargs.pop(ATTR_COLOR_TEMP_KELVIN, None)
+
+            if kelvin is None and mireds is not None:
+                kelvin = color_temperature_mired_to_kelvin(mireds)
+
+            if kelvin is not None:
                 if self.channel.has(ATTR_COLOR_TEMP_KELVIN):
                     success = await self.device.async_set_state(
                         self.channel, ATTR_COLOR_TEMP_KELVIN, kelvin
@@ -387,11 +374,12 @@ class UniledLightEntity(
                     success = await self.device.async_set_state(
                         self.channel, ATTR_UL_CCT_COLOR, (cold, warm, level, kelvin)
                     )
-                elif self.channel.has(ATTR_COLOR_TEMP):
-                    if mireds is not None:
-                        await self.device.async_set_state(
-                            self.channel, ATTR_COLOR_TEMP, mireds
-                        )
+                elif self.channel.has(ATTR_COLOR_TEMP_LEGACY):
+                    success = await self.device.async_set_state(
+                        self.channel,
+                        ATTR_COLOR_TEMP_LEGACY,
+                        color_temperature_kelvin_to_mired(kelvin),
+                    )
 
             # Process any other commands
             #


### PR DESCRIPTION
Home Assistant 2026.3 introduced stricter validation for LightEntity
supported_color_modes and no longer accepts combinations such as
{RGB, BRIGHTNESS}, since RGB already implies brightness support.

The BanlanX BLE driver was still advertising both color modes, causing
Home Assistant to reject the light entity during setup with:

"Invalid supported_color_modes ['brightness', 'rgb']"

This change removes the redundant BRIGHTNESS mode whenever an RGB color
mode is present, restoring compatibility with Home Assistant 2026.3+
while preserving the original device functionality.