### PR TITLE
Fix RGB-only static color mode detection

### DIFF
--- a/custom_components/uniled/lib/ble/banlanx_6xx.py
+++ b/custom_components/uniled/lib/ble/banlanx_6xx.py
@@ -1080,7 +1080,7 @@ class BanlanX6xx(SP6xxEProxy):
                             device.master.set(ATTR_HA_WHITE, white_level)
                             white_mode = COLOR_MODE_WHITE
                             supported_color_modes.add(white_mode)
-                        else:
+                        elif cfg.white:
                             # Fix Issue #73, #77
                             # supported_color_modes = set(white_mode)
                             supported_color_modes.add(white_mode)


### PR DESCRIPTION
## Summary

Fix RGB-only static color mode detection for BanlanX SP6xxE controllers.

The issue occurs with an RGB-only SPI configuration (CFG_86 / SP5XXE_86), where white_mode was not initialized before being referenced during static color decoding.

This caused repeated decoding exceptions and prevented the LED Lighting from being properly added to Home Assistant.

Tested with a real SPI RGB controller running in Static Color mode. After the fix, the lighting entity loads correctly, and Home Assistant no longer reports the invalid supported color mode or white_mode exceptions.

The tested controller reports:

Configuration: SP5XXE_86
Light type: SPI RGB
Chip order: RGB
Firmware: V3007.01